### PR TITLE
Add private platform admin and auth hardening

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -5,6 +5,7 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 REVISELAB_SITE_URL=http://127.0.0.1:3000
 REVISELAB_DIAGNOSTICS_ENABLED=false
+REVISELAB_ADMIN_EMAILS=
 # For hosted Supabase dev, prefer the Session pooler or Transaction pooler URL.
 # Direct db.<project>.supabase.co:5432 URLs can be IPv6-only.
 DATABASE_URL=

--- a/apps/web/app/(app)/admin/platform/page.tsx
+++ b/apps/web/app/(app)/admin/platform/page.tsx
@@ -1,0 +1,124 @@
+import { notFound } from "next/navigation";
+
+import {
+  Column,
+  Grid,
+  InlineNotification,
+  Tag,
+  Tile,
+} from "@reviselab/ui/carbon";
+
+import {
+  getPlatformOpsSnapshot,
+  type PlatformMetric,
+} from "@/lib/admin/platform-ops";
+import { requireViewerContext } from "@/lib/auth/session";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function getTagType(status: PlatformMetric["status"]) {
+  switch (status) {
+    case "ok":
+      return "green";
+    case "warning":
+      return "warm-gray";
+    case "error":
+      return "red";
+  }
+}
+
+export default async function PlatformAdminPage() {
+  const viewer = await requireViewerContext("/admin/platform");
+
+  if (!viewer.isPlatformAdmin) {
+    notFound();
+  }
+
+  const snapshot = await getPlatformOpsSnapshot();
+  const hasError = snapshot.metrics.some((metric) => metric.status === "error");
+  const hasWarning = snapshot.metrics.some(
+    (metric) => metric.status === "warning",
+  );
+
+  return (
+    <Grid fullWidth className="rl-page-grid">
+      <Column sm={4} md={8} lg={16}>
+        <Tile className="rl-section">
+          <div className="rl-page-header">
+            <div className="rl-page-header-copy">
+              <p className="rl-eyebrow">Private platform operations</p>
+              <h1>Platform admin</h1>
+              <p className="rl-muted">
+                Monitor production health without exposing diagnostics to normal
+                users.
+              </p>
+            </div>
+            <Tag type={hasError ? "red" : hasWarning ? "warm-gray" : "green"}>
+              {hasError ? "Action needed" : hasWarning ? "Watch" : "Ready"}
+            </Tag>
+          </div>
+        </Tile>
+      </Column>
+
+      {hasError ? (
+        <Column sm={4} md={8} lg={16}>
+          <InlineNotification
+            lowContrast
+            kind="error"
+            title="Platform needs attention"
+            subtitle="Review failing checks, queue depth, and recent failure events before trusting new production uploads."
+          />
+        </Column>
+      ) : null}
+
+      {snapshot.metrics.map((metric) => (
+        <Column key={metric.label} sm={4} md={4} lg={8}>
+          <Tile className="rl-section">
+            <div className="rl-section-header">
+              <h2>{metric.label}</h2>
+              <Tag type={getTagType(metric.status)}>{metric.status}</Tag>
+            </div>
+            <p className="rl-metric">{metric.value}</p>
+            <p className="rl-muted">{metric.detail}</p>
+          </Tile>
+        </Column>
+      ))}
+
+      <Column sm={4} md={8} lg={16}>
+        <Tile className="rl-section">
+          <div className="rl-section-header">
+            <h2>Recent parse and review failures</h2>
+            <Tag type={snapshot.failures.length > 0 ? "warm-gray" : "green"}>
+              {snapshot.failures.length}
+            </Tag>
+          </div>
+          {snapshot.failures.length > 0 ? (
+            <div className="rl-stack">
+              {snapshot.failures.map((failure) => (
+                <div key={failure.id} className="rl-admin-event">
+                  <p>
+                    <strong>{failure.label}</strong>{" "}
+                    <span className="rl-muted">{failure.kind}</span>
+                  </p>
+                  <p className="rl-muted">
+                    {failure.detail ?? "No detail recorded."}
+                  </p>
+                  <p className="rl-muted">{failure.createdAt}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="rl-muted">
+              No recent parse or review failures recorded.
+            </p>
+          )}
+        </Tile>
+      </Column>
+
+      <Column sm={4} md={8} lg={16}>
+        <p className="rl-muted">Last checked {snapshot.generatedAt}</p>
+      </Column>
+    </Grid>
+  );
+}

--- a/apps/web/app/(app)/dashboard/page.tsx
+++ b/apps/web/app/(app)/dashboard/page.tsx
@@ -1,5 +1,11 @@
 import { DashboardControlPlane } from "@reviselab/ui";
-import { Button, Column, Grid, Tile } from "@reviselab/ui/carbon";
+import {
+  Button,
+  Column,
+  Grid,
+  InlineNotification,
+  Tile,
+} from "@reviselab/ui/carbon";
 
 import { DashboardLiveRefresh } from "@/components/dashboard-live-refresh";
 import { listDashboardReviews } from "@/lib/reviews/repository";
@@ -7,7 +13,16 @@ import { listDashboardReviews } from "@/lib/reviews/repository";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-export default async function DashboardPage() {
+type DashboardPageProps = {
+  searchParams: Promise<{
+    welcome?: string;
+  }>;
+};
+
+export default async function DashboardPage({
+  searchParams,
+}: DashboardPageProps) {
+  const { welcome } = await searchParams;
   const reviews = await listDashboardReviews();
 
   return (
@@ -36,6 +51,17 @@ export default async function DashboardPage() {
             </div>
           </Tile>
         </Column>
+
+        {welcome === "workspace-created" ? (
+          <Column sm={4} md={8} lg={16}>
+            <InlineNotification
+              lowContrast
+              kind="success"
+              title="Workspace ready"
+              subtitle="Your profile, personal workspace, and owner membership were created. You can start your first manuscript review."
+            />
+          </Column>
+        ) : null}
 
         <Column sm={4} md={8} lg={16}>
           <DashboardControlPlane rows={reviews} newReviewHref="/reviews/new" />

--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -24,6 +24,7 @@ export default async function DashboardLayout({
         brandName={brandConfig.name}
         authHref="/auth/sign-out"
         authLabel="Sign out"
+        showAdmin={viewer.isPlatformAdmin}
         showDiagnostics={isDiagnosticsEnabled()}
       />
       <Content>

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -66,7 +66,14 @@ export async function GET(request: Request) {
   }
 
   try {
-    await getViewerContext();
+    const viewer = await getViewerContext();
+    const redirectUrl = new URL(nextPath, url.origin);
+
+    if (viewer?.createdWorkspace && redirectUrl.pathname === "/dashboard") {
+      redirectUrl.searchParams.set("welcome", "workspace-created");
+    }
+
+    return NextResponse.redirect(redirectUrl);
   } catch (error) {
     return NextResponse.redirect(
       new URL(
@@ -79,6 +86,4 @@ export async function GET(request: Request) {
       ),
     );
   }
-
-  return NextResponse.redirect(new URL(nextPath, url.origin));
 }

--- a/apps/web/components/auth-error-hash-cleaner.tsx
+++ b/apps/web/components/auth-error-hash-cleaner.tsx
@@ -5,21 +5,52 @@ import { useEffect } from "react";
 const AUTH_ERROR_HASH_PATTERN =
   /(?:^|[&#])(?:error|error_code|error_description)=|otp_expired/;
 
+function getAuthErrorFromHash(hash: string) {
+  const params = new URLSearchParams(hash.replace(/^#/, ""));
+  const code = params.get("error_code");
+  const description = params.get("error_description") ?? params.get("error");
+
+  if (!description) {
+    return null;
+  }
+
+  return {
+    code,
+    message:
+      code === "otp_expired"
+        ? "That magic link has already been used or expired. Send a fresh magic link and open the newest email once in this browser."
+        : description,
+  };
+}
+
 export function AuthErrorHashCleaner() {
   useEffect(() => {
     const { hash, pathname, search } = window.location;
 
-    if (
-      hash &&
-      pathname !== "/auth/sign-in" &&
-      AUTH_ERROR_HASH_PATTERN.test(hash)
-    ) {
-      window.history.replaceState(
-        window.history.state,
-        "",
-        `${pathname}${search}`,
-      );
+    if (!hash || !AUTH_ERROR_HASH_PATTERN.test(hash)) {
+      return;
     }
+
+    const authError = getAuthErrorFromHash(hash);
+
+    if (authError) {
+      const signInUrl = new URL("/auth/sign-in", window.location.origin);
+      signInUrl.searchParams.set("next", pathname);
+      signInUrl.searchParams.set("error", authError.message);
+
+      if (authError.code) {
+        signInUrl.searchParams.set("errorCode", authError.code);
+      }
+
+      window.location.replace(signInUrl);
+      return;
+    }
+
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${pathname}${search}`,
+    );
   }, []);
 
   return null;

--- a/apps/web/lib/admin/platform-ops.ts
+++ b/apps/web/lib/admin/platform-ops.ts
@@ -1,0 +1,205 @@
+import "server-only";
+
+import postgres from "postgres";
+
+import { getLiveStackDiagnostics } from "@/lib/diagnostics/live-stack";
+import {
+  getDatabaseUrl,
+  getHostedPoolerMessage,
+  getSupabaseEnv,
+  isDirectHostedSupabaseDatabaseUrl,
+  isLocalSupabaseUrl,
+} from "@/lib/supabase/env";
+
+export type PlatformMetric = {
+  label: string;
+  value: string;
+  detail: string;
+  status: "ok" | "warning" | "error";
+};
+
+export type PlatformFailure = {
+  id: string;
+  kind: string;
+  label: string;
+  detail: string | null;
+  createdAt: string;
+};
+
+export type PlatformOpsSnapshot = {
+  generatedAt: string;
+  metrics: PlatformMetric[];
+  failures: PlatformFailure[];
+};
+
+function formatCount(value: unknown) {
+  return String(Number(value ?? 0));
+}
+
+function getFreshnessStatus(createdAt: Date | null): PlatformMetric["status"] {
+  if (!createdAt) {
+    return "warning";
+  }
+
+  const ageMs = Date.now() - createdAt.getTime();
+
+  if (ageMs > 5 * 60_000) {
+    return "error";
+  }
+
+  if (ageMs > 2 * 60_000) {
+    return "warning";
+  }
+
+  return "ok";
+}
+
+function buildUnavailableSnapshot(detail: string): PlatformOpsSnapshot {
+  return {
+    generatedAt: new Date().toISOString(),
+    metrics: [
+      {
+        label: "Platform database",
+        value: "Unavailable",
+        detail,
+        status: "error",
+      },
+    ],
+    failures: [],
+  };
+}
+
+export async function getPlatformOpsSnapshot(): Promise<PlatformOpsSnapshot> {
+  const databaseUrl = getDatabaseUrl();
+  const env = getSupabaseEnv();
+
+  if (!databaseUrl) {
+    return buildUnavailableSnapshot("DATABASE_URL is not configured.");
+  }
+
+  if (isDirectHostedSupabaseDatabaseUrl(databaseUrl)) {
+    return buildUnavailableSnapshot(getHostedPoolerMessage());
+  }
+
+  const sql = postgres(databaseUrl, {
+    max: 1,
+    prepare: false,
+    connect_timeout: 10,
+    ssl: env && !isLocalSupabaseUrl(env.url) ? "require" : false,
+  });
+
+  try {
+    const [diagnostics, counts, queues, heartbeat, failures] =
+      await Promise.all([
+        getLiveStackDiagnostics(),
+        sql`
+          select
+            (select count(*)::int from public.profiles) as profiles,
+            (select count(*)::int from public.workspaces) as workspaces,
+            (select count(*)::int from public.reviews) as reviews,
+            (select count(*)::int from public.reviews where status = 'failed') as failed_reviews,
+            (select count(*)::int from public.paper_versions where parse_status = 'failed') as failed_parses
+        `,
+        sql`
+          select
+            (select count(*)::int from pgmq.q_parse_paper) as parse_queue,
+            (select count(*)::int from pgmq.q_run_review) as review_queue
+        `,
+        sql`
+          select created_at
+          from public.usage_events
+          where event_name = 'worker_heartbeat'
+          order by created_at desc
+          limit 1
+        `,
+        sql`
+          select id, event_kind, label, detail, created_at
+          from public.review_events
+          where event_kind in ('parse_failed', 'review_failed')
+          order by created_at desc
+          limit 10
+        `,
+      ]);
+
+    const countRow = counts[0];
+    const queueRow = queues[0];
+    const heartbeatAt = heartbeat[0]?.created_at
+      ? new Date(heartbeat[0].created_at)
+      : null;
+    const failingChecks = diagnostics.checks.filter(
+      (check) => check.status !== "ok",
+    );
+
+    return {
+      generatedAt: new Date().toISOString(),
+      metrics: [
+        {
+          label: "Stack health",
+          value: failingChecks.length === 0 ? "Ready" : "Needs attention",
+          detail:
+            failingChecks.length === 0
+              ? "Auth, database, storage, queues, worker heartbeat, and GROBID are healthy."
+              : failingChecks
+                  .map((check) => `${check.label}: ${check.detail}`)
+                  .join(" "),
+          status: failingChecks.some((check) => check.status === "error")
+            ? "error"
+            : failingChecks.length > 0
+              ? "warning"
+              : "ok",
+        },
+        {
+          label: "Worker heartbeat",
+          value: heartbeatAt ? heartbeatAt.toISOString() : "Missing",
+          detail: heartbeatAt
+            ? "Worker heartbeat is recorded from the background processor."
+            : "No worker heartbeat has been recorded.",
+          status: getFreshnessStatus(heartbeatAt),
+        },
+        {
+          label: "Queue depth",
+          value: `${formatCount(queueRow?.parse_queue)} parse / ${formatCount(
+            queueRow?.review_queue,
+          )} review`,
+          detail: "Messages currently present in PGMQ queues.",
+          status:
+            Number(queueRow?.parse_queue ?? 0) +
+              Number(queueRow?.review_queue ?? 0) >
+            20
+              ? "warning"
+              : "ok",
+        },
+        {
+          label: "Review failures",
+          value: `${formatCount(countRow?.failed_reviews)} review / ${formatCount(
+            countRow?.failed_parses,
+          )} parse`,
+          detail: "Current failed review and parse records.",
+          status:
+            Number(countRow?.failed_reviews ?? 0) +
+              Number(countRow?.failed_parses ?? 0) >
+            0
+              ? "warning"
+              : "ok",
+        },
+        {
+          label: "Accounts",
+          value: `${formatCount(countRow?.profiles)} profiles`,
+          detail: `${formatCount(countRow?.workspaces)} workspaces and ${formatCount(
+            countRow?.reviews,
+          )} reviews exist in the platform database.`,
+          status: "ok",
+        },
+      ],
+      failures: failures.map((failure) => ({
+        id: String(failure.id),
+        kind: String(failure.event_kind),
+        label: String(failure.label),
+        detail: failure.detail ? String(failure.detail) : null,
+        createdAt: new Date(failure.created_at).toISOString(),
+      })),
+    };
+  } finally {
+    await sql.end({ timeout: 2 });
+  }
+}

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { redirect } from "next/navigation";
 
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getPlatformAdminEmails } from "@/lib/supabase/env";
 
 const DEFAULT_SIGN_IN_PATH = "/auth/sign-in";
 
@@ -11,6 +12,8 @@ export type ViewerContext = {
   email: string | null;
   displayName: string | null;
   workspaceId: string;
+  isPlatformAdmin: boolean;
+  createdWorkspace: boolean;
 };
 
 function throwIfSupabaseError(
@@ -94,6 +97,7 @@ export async function getViewerContext(): Promise<ViewerContext | null> {
   throwIfSupabaseError(membershipError, "Unable to load workspace membership.");
 
   const workspaceId = membership?.workspace_id ?? buildWorkspaceId(userId);
+  const createdWorkspace = !membership;
 
   if (!membership) {
     const { error: workspaceError } = await supabase.from("workspaces").upsert(
@@ -134,6 +138,10 @@ export async function getViewerContext(): Promise<ViewerContext | null> {
     email,
     displayName,
     workspaceId,
+    isPlatformAdmin: email
+      ? getPlatformAdminEmails().includes(email.toLowerCase())
+      : false,
+    createdWorkspace,
   };
 }
 

--- a/apps/web/lib/supabase/env.ts
+++ b/apps/web/lib/supabase/env.ts
@@ -40,6 +40,13 @@ export function isDiagnosticsEnabled() {
   return process.env.REVISELAB_DIAGNOSTICS_ENABLED === "true";
 }
 
+export function getPlatformAdminEmails() {
+  return (process.env.REVISELAB_ADMIN_EMAILS ?? "")
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+}
+
 export function isDirectHostedSupabaseDatabaseUrl(
   databaseUrl = getDatabaseUrl(),
 ) {

--- a/docs/railway-deployment.md
+++ b/docs/railway-deployment.md
@@ -26,6 +26,7 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 REVISELAB_SITE_URL=https://reviselab-production.up.railway.app
 REVISELAB_DIAGNOSTICS_ENABLED=false
+REVISELAB_ADMIN_EMAILS=
 DATABASE_URL=
 GROBID_URL=
 ```
@@ -40,6 +41,11 @@ links from being generated with internal hosts such as `0.0.0.0`.
 Keep `REVISELAB_DIAGNOSTICS_ENABLED=false` in production unless actively
 debugging. When it is not `true`, `/settings/diagnostics` returns a 404 and the
 Diagnostics nav item is hidden from signed-in users.
+
+Set `REVISELAB_ADMIN_EMAILS` to a comma-separated list of trusted operator
+emails. Those users can access `/admin/platform`, which shows private stack
+health, worker heartbeat freshness, queue depth, failure counts, and recent
+parse/review failures.
 
 ## Worker service
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
     "node": "24.14.0",
     "pnpm": "10.33.0"
   },
+  "pnpm": {
+    "overrides": {
+      "postcss": "^8.5.10",
+      "uuid": "^14.0.0"
+    }
+  },
   "scripts": {
     "audit:repo": "pnpm clean && pnpm check && pnpm test:visual && pnpm clean",
     "build": "pnpm -r --if-present build",
@@ -37,6 +43,7 @@
     "rules:precision": "node ./scripts/rules-precision.mjs",
     "rules:precision:llm": "node ./scripts/rules-precision-llm.mjs",
     "smoke:hosted": "node ./scripts/smoke-hosted-review.mjs",
+    "smoke:hosted:auth": "node ./scripts/smoke-auth-redirect.mjs",
     "smoke:hosted:pdf": "node ./scripts/smoke-hosted-review.mjs --pdf",
     "smoke:hosted:pdf:expect-failure": "node ./scripts/smoke-hosted-review.mjs --pdf --expect-failure",
     "smoke:live": "node ./scripts/smoke-live-review.mjs",

--- a/packages/ui/src/components/app-header.tsx
+++ b/packages/ui/src/components/app-header.tsx
@@ -10,6 +10,7 @@ type AppHeaderProps = {
   brandName: string;
   authHref?: string;
   authLabel?: string;
+  showAdmin?: boolean;
   showDiagnostics?: boolean;
 };
 
@@ -17,6 +18,7 @@ export function AppHeader({
   brandName,
   authHref = "/auth/sign-in",
   authLabel = "Sign in",
+  showAdmin = false,
   showDiagnostics = false,
 }: AppHeaderProps) {
   return (
@@ -32,6 +34,11 @@ export function AppHeader({
           <HeaderMenuItem href="/settings/integrations">
             Integrations
           </HeaderMenuItem>
+          {showAdmin ? (
+            <HeaderMenuItem href="/admin/platform">
+              Platform admin
+            </HeaderMenuItem>
+          ) : null}
           {showDiagnostics ? (
             <HeaderMenuItem href="/settings/diagnostics">
               Diagnostics

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -217,6 +217,30 @@ a {
   color: var(--cds-text-secondary);
 }
 
+.rl-metric {
+  margin: 0;
+  font-size: var(--cds-heading-04-font-size);
+  font-weight: var(--cds-heading-04-font-weight);
+  line-height: var(--cds-heading-04-line-height);
+  letter-spacing: var(--cds-heading-04-letter-spacing);
+}
+
+.rl-stack {
+  display: grid;
+  gap: var(--cds-spacing-05);
+}
+
+.rl-admin-event {
+  display: grid;
+  gap: var(--cds-spacing-02);
+  padding-block: var(--cds-spacing-04);
+  border-block-start: 1px solid var(--cds-border-subtle);
+}
+
+.rl-admin-event p {
+  margin: 0;
+}
+
 @media (min-width: 1056px) {
   .rl-header-actions {
     inline-size: auto;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: ^8.5.10
+  uuid: ^14.0.0
+
 importers:
 
   .:
@@ -3391,10 +3395,6 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4026,8 +4026,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vfile-message@3.1.4:
@@ -7402,7 +7402,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.21
       caniuse-lite: 1.0.30001790
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
@@ -7442,7 +7442,7 @@ snapshots:
       is-wsl: 2.2.0
       semver: 7.7.4
       shellwords: 0.1.1
-      uuid: 8.3.2
+      uuid: 14.0.0
       which: 2.0.2
 
   node-releases@2.0.38: {}
@@ -7639,12 +7639,6 @@ snapshots:
       fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.10:
     dependencies:
@@ -8406,7 +8400,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   vfile-message@3.1.4:
     dependencies:

--- a/scripts/smoke-auth-redirect.mjs
+++ b/scripts/smoke-auth-redirect.mjs
@@ -1,0 +1,119 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { ROOT, assert, readHostedWebEnv } from "./local-stack-lib.mjs";
+
+const reportPath = path.join(ROOT, ".local-runtime", "auth-smoke-report.json");
+
+async function writeReport(report) {
+  await mkdir(path.dirname(reportPath), { recursive: true });
+  await writeFile(
+    reportPath,
+    `${JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        ...report,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function getSmokeEmail(env) {
+  return (
+    process.env.REVISELAB_AUTH_SMOKE_EMAIL ??
+    env.REVISELAB_ADMIN_EMAILS?.split(",")[0]?.trim() ??
+    null
+  );
+}
+
+async function main() {
+  const env = readHostedWebEnv();
+  const siteUrl = env.REVISELAB_SITE_URL;
+  const smokeEmail = getSmokeEmail(env);
+
+  assert(siteUrl, "REVISELAB_SITE_URL is missing.");
+  assert(
+    smokeEmail,
+    "Set REVISELAB_AUTH_SMOKE_EMAIL or REVISELAB_ADMIN_EMAILS.",
+  );
+
+  const callbackUrl = new URL("/auth/callback", siteUrl);
+  callbackUrl.searchParams.set("next", "/dashboard");
+
+  assert(
+    callbackUrl.origin === new URL(siteUrl).origin,
+    "Auth callback origin does not match REVISELAB_SITE_URL.",
+  );
+  assert(
+    !callbackUrl.href.includes("0.0.0.0") &&
+      !callbackUrl.href.includes(":8080"),
+    "Auth callback contains an internal Railway origin.",
+  );
+
+  const response = await fetch(
+    `${env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/admin/generate_link`,
+    {
+      method: "POST",
+      headers: {
+        apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+        authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        type: "magiclink",
+        email: smokeEmail,
+        options: {
+          redirect_to: callbackUrl.toString(),
+        },
+      }),
+    },
+  );
+
+  const body = await response.json().catch(() => ({}));
+
+  assert(response.ok, body?.msg ?? "Supabase auth link generation failed.");
+  const actionLink =
+    typeof body.action_link === "string" ? new URL(body.action_link) : null;
+  const redirectTo = actionLink?.searchParams.get("redirect_to");
+
+  assert(
+    redirectTo && new URL(redirectTo).origin === new URL(siteUrl).origin,
+    "Generated auth link does not use the production site URL.",
+  );
+  assert(
+    !String(redirectTo).includes("0.0.0.0") &&
+      !String(redirectTo).includes(":8080"),
+    "Generated auth link contains an internal Railway origin.",
+  );
+
+  const callbackResponse = await fetch(callbackUrl, {
+    method: "HEAD",
+    redirect: "manual",
+  });
+
+  assert(
+    callbackResponse.status >= 300 && callbackResponse.status < 400,
+    `Auth callback route returned ${callbackResponse.status}.`,
+  );
+
+  await writeReport({
+    status: "passed",
+    callbackOrigin: callbackUrl.origin,
+    generatedRedirectOrigin: new URL(redirectTo).origin,
+    generatedLink: "redacted",
+  });
+
+  console.log("Hosted auth redirect smoke passed.");
+  console.log(`- Callback origin: ${callbackUrl.origin}`);
+}
+
+main().catch(async (error) => {
+  await writeReport({
+    status: "failed",
+    error: error instanceof Error ? error.message : "Auth smoke failed.",
+  }).catch(() => {});
+  console.error(error instanceof Error ? error.message : "Auth smoke failed.");
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Enable admin enforcement on main branch protection and stop relying on direct main pushes
- Resolve Dependabot transitive alerts with pnpm overrides for postcss and uuid
- Add private /admin/platform ops dashboard gated by REVISELAB_ADMIN_EMAILS
- Keep /settings/diagnostics disabled for normal users while surfacing stack health, queue depth, worker heartbeat, and recent parse/review failures to admins
- Add production-safe hosted auth redirect smoke and improve expired-link hash handling
- Add workspace-created onboarding confirmation after first successful sign-in

## Verification
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:visual
- pnpm prod:check
- pnpm smoke:hosted:auth
- pnpm audit --audit-level moderate

## Notes
- Railway web env now has REVISELAB_ADMIN_EMAILS set from local git config email.
- Dependabot alerts remain visible on main until this PR merges.